### PR TITLE
liskov_principle_part1

### DIFF
--- a/solid-java.iml
+++ b/solid-java.iml
@@ -3,7 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/2051-solid-java-projeto_inicial/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/solid_na_pratica/src" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/solid_na_pratica/src/br/com/alura/rh/model/Cargo.java
+++ b/solid_na_pratica/src/br/com/alura/rh/model/Cargo.java
@@ -1,10 +1,34 @@
 package br.com.alura.rh.model;
 
+
+//enums podem ter metódos, e assim, te ajudar com a implementação da sua regra de negócio, além de ajudar no encapsulamento.
 public enum Cargo {
 
-	ASSISTENTE,
-	ANALISTA,
-	ESPECIALISTA,
-	GERENTE;
+	ASSISTENTE{
+		@Override
+		public Cargo getProximoCargo() {
+			return ANALISTA;
+		}
+	},
+	ANALISTA {
+		@Override
+		public Cargo getProximoCargo() {
+			return ESPECIALISTA;
+		}
+	},
+	ESPECIALISTA {
+		@Override
+		public Cargo getProximoCargo() {
+			return GERENTE;
+		}
+	},
+	GERENTE {
+		@Override
+		public Cargo getProximoCargo() {
+			return GERENTE;
+		}
+	};
+
+	public  abstract Cargo getProximoCargo();
 
 }

--- a/solid_na_pratica/src/br/com/alura/rh/model/Funcionario.java
+++ b/solid_na_pratica/src/br/com/alura/rh/model/Funcionario.java
@@ -67,4 +67,8 @@ public class Funcionario {
         this.dataUltimoReajuste = LocalDate.now();
 
     }
+
+    public void promove(Cargo novoCargo) {
+        this.cargo = novoCargo;
+    }
 }

--- a/solid_na_pratica/src/br/com/alura/rh/model/Terceirizado.java
+++ b/solid_na_pratica/src/br/com/alura/rh/model/Terceirizado.java
@@ -1,0 +1,21 @@
+package br.com.alura.rh.model;
+
+import java.math.BigDecimal;
+
+public class Terceirizado extends Funcionario{
+
+
+    private String Empresa;
+
+    public Terceirizado(String nome, String cpf, Cargo cargo, BigDecimal salario) {
+        super(nome, cpf, cargo, salario);
+    }
+
+    public String getEmpresa() {
+        return Empresa;
+    }
+
+    public void setEmpresa(String empresa) {
+        Empresa = empresa;
+    }
+}

--- a/solid_na_pratica/src/br/com/alura/rh/service/promocao/PromocaoService.java
+++ b/solid_na_pratica/src/br/com/alura/rh/service/promocao/PromocaoService.java
@@ -1,0 +1,22 @@
+package br.com.alura.rh.service.promocao;
+
+import br.com.alura.rh.ValidacaoException;
+import br.com.alura.rh.model.Cargo;
+import br.com.alura.rh.model.Funcionario;
+
+public class PromocaoService {
+    public void promove(Funcionario funcionario, boolean metaBatida) {
+        Cargo cargoAtual = funcionario.getCargo();
+        if (Cargo.GERENTE == cargoAtual) {
+            throw new ValidacaoException("Este funcionário ja possui o cargo máximo");
+        }
+        if (metaBatida) {
+            Cargo novoCargo = cargoAtual.getProximoCargo();
+            funcionario.promove(novoCargo);
+        }else {
+            throw new ValidacaoException("a meta não foi batida");
+
+        }
+    }
+
+}


### PR DESCRIPTION
Primeira Parte do principio de substituição de liskov, onde criamos uma nova classe que aparentemente é de funcionários terceirizados, utilizando a herança para herdar os atributos base para reaproveitamento, porém assim a classse herda metodos que não fazem sentido pra ela, trazendo danos para a aplicação, podemos utilizar a composição ao invés da herança em casos assim, criamos uma classe "base" onde há atributos comuns que outras classes necessitem e dai colocamos um atributo deste tipo nelas.